### PR TITLE
Porting typed operation to using literal

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,9 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # ruby: [ "2.7", "3.0", "3.1", "3.2" ]
-        ruby: [ "3.0", "3.1", "3.2" ]
-        # rails: [ "6.0", "7.0" ]
+        ruby: [ "3.1", "3.2" ]
         rails: [ "7.0" ]
     steps:
       - uses: actions/checkout@v3

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@
 .idea/
 Gemfile.lock
 *.gem
+/coverage/
+.tool-versions

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## [0.5.0] - Unreleased
+
+### Breaking changes
+
+- TypedOperation now uses [Literal::Data](https://github.com/joeldrapper/literal) under the hood, instead of [vident-typed](https://github.com/stevegeek/vident-typed)
+
+### Changed
+
+- TypedOperation does not depend on Rails. Rails generator support exists but is conditionally included.
+
 ## [0.4.2] - Unreleased
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Breaking changes
 
 - TypedOperation now uses [Literal::Data](https://github.com/joeldrapper/literal) under the hood, instead of [vident-typed](https://github.com/stevegeek/vident-typed)
+- param 'convert:' option has been removed, use a coercion block instead
 
 ### Changed
 
@@ -14,14 +15,14 @@
 
 - Params that have default values are no longer required to prepare the operation.
 
-## [0.4.1] - 2023/06/22
+## [0.4.1] - 2023-06-22
 
 ### Changed
 
 - Updated tests.
 - Tweaked operation templates.
 
-## [0.4.0] - 2023/06/22
+## [0.4.0] - 2023-06-22
 
 ### Removed
 
@@ -35,7 +36,7 @@
 
 - Avoided leaking the implementation detail of using dry-struct under the hood.
 
-## [0.3.0] - 2023/06/19
+## [0.3.0] - 2023-06-19
 
 ### Removed
 
@@ -56,7 +57,7 @@
 
 - Fixed 'require's.
 
-## [0.1.0] - Unreleased
+## [0.1.0] - 2023-05-04
 
 ### Added
 

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,84 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our community a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, religion, or sexual identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes, and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or
+  advances of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email
+  address, without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of acceptable behavior and will take appropriate and fair corrective action in response to any behavior that they deem inappropriate, threatening, offensive, or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, and will communicate reasons for moderation decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when an individual is officially representing the community in public spaces. Examples of representing our community include using an official e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement at stevegeek@gmail.com. All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing clarity around the nature of the violation and an explanation of why the behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, for a specified period of time. This includes avoiding interactions in community spaces as well as external channels like social media. Violating these terms may lead to a temporary or permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public communication with the community for a specified period of time. No public or private interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, is allowed during this period. Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community standards, including sustained inappropriate behavior,  harassment of an individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 2.0,
+available at https://www.contributor-covenant.org/version/2/0/code_of_conduct.html.
+
+Community Impact Guidelines were inspired by [Mozilla's code of conduct enforcement ladder](https://github.com/mozilla/diversity).
+
+[homepage]: https://www.contributor-covenant.org
+
+For answers to common questions about this code of conduct, see the FAQ at
+https://www.contributor-covenant.org/faq. Translations are available at https://www.contributor-covenant.org/translations.

--- a/Gemfile
+++ b/Gemfile
@@ -4,11 +4,16 @@ git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 # Specify your gem's dependencies in typed_operation.gemspec.
 gemspec
 
+gem "rails"
+
 gem "sqlite3"
 
 gem "standard"
 
 gem "dry-monads"
+
+# TODO: move to gemspec when released
+gem "literal", ">= 0.1.0", github: "joeldrapper/literal", branch: "main"
 
 # Start debugger with binding.b [https://github.com/ruby/debug]
 # gem "debug", ">= 1.0.0"

--- a/Gemfile
+++ b/Gemfile
@@ -15,5 +15,11 @@ gem "dry-monads"
 # TODO: move to gemspec when released
 gem "literal", ">= 0.1.0", github: "joeldrapper/literal", branch: "main"
 
+gem "simplecov"
+
 # Start debugger with binding.b [https://github.com/ruby/debug]
 # gem "debug", ">= 1.0.0"
+
+if Gem::Version.new(RUBY_VERSION) < Gem::Version.new("3.2.0")
+  gem "polyfill-data"
+end

--- a/README.md
+++ b/README.md
@@ -1,62 +1,310 @@
 # TypedOperation
 
-An implementation of a Command pattern, which is callable, and can be partially applied (curried).
+An implementation of a Command pattern, which is callable, and can be partially applied.
 
-Inputs to the operation are specified as typed attributes using the `param` method.
+Inputs to the operation are specified as typed attributes (uses [`literal`](https://github.com/joeldrapper/literal)).
 
-Result format of the operation is up to you, but plays nicely with `Dry::Monads`. 
+Type of result of the operation is up to you, but plays nicely with `literal` result or [`Dry::Monads`](https://dry-rb.org/gems/dry-monads/1.3/).
 
-### Examples:
+## Features
 
-#### A simple operation:
+- Operations can be **partially applied** or **curried**
+- Operations are **callable**
+- Operations can be **pattern matched** on
+- Parameters:
+  - specified with **type constraints** (uses `literal` gem)
+  - can be **positional** or **named**
+  - can be **optional**, or have **default** values
+  - can be **coerced** by providing a block
+
+### Example
+
+```ruby
+class ShelveBookOperation < ::TypedOperation::Base
+  # Parameters
+  positional :title, String
+  named :description, String
+  named :author_id, Integer, &:to_i
+  named :isbn, String
+  named :shelf_code, optional(Integer), default: GENERIC_SHELF_CODE
+
+  # to setup (optional)
+  def prepare
+    raise ArgumentError, "ISBN is invalid" unless valid_isbn?
+  end
+
+  # The 'work' of the operation
+  def call
+    # Creat a book on the shelf
+    # ...
+  end
+
+  private
+
+  def valid_isbn?
+    # ...
+  end
+end
+
+ShelveBookOperation.call("The Hobbit", description: "A book about a hobbit", author_id: "1", isbn: "978-0261103283")
+```
+
+### Partially applying parameters
 
 ```ruby
 class TestOperation < ::TypedOperation::Base
-  param :foo, String
-  param :bar, String
-  param :baz, String do |value|
-    value.to_s
-  end
+  positional :foo, String
+  named :bar, String
+  named :baz, String, &:to_s
 
-  def prepare
-    # to setup (optional)
-    puts "lets go!"
-  end
-  
-  def call
-    "It worked!"
-  end
+  def call = "It worked! (#{foo}, #{bar}, #{baz})"
 end
-```
 
-```ruby
-TestOperation.(foo: "1", bar: "2", baz: 3)
-# => "It worked!"
+# Invoking the operation directly
+TestOperation.("1", bar: "2", baz: 3)
+# => "It worked! (1, 2, 3)"
 
-TestOperation.with(foo: "1").with(bar: "2")
-# => #<TypedOperation::PartiallyApplied:0x000000014a655310 @applied_args={:foo=>"1", :bar=>"2"}, @operation=TestOperation>
+# Partial application of parameters
+partially_applied = TestOperation.with("1").with(bar: "2")
+# => #<TypedOperation::PartiallyApplied:0x0000000110270248 @keyword_args={:bar=>"2"}, @operation_class=TestOperation, @positional_args=["1"]>
 
-TestOperation.with(foo: "1").with(bar: "2").with(baz: 3)
-# => <TypedOperation::Prepared:0x000000012dac6498 @applied_args={:foo=>"1", :bar=>"2", :baz=>3}, @operation=TestOperation>
+# You can partially apply more than one parameter at a time, and chain calls to `.with`.
+# With all the required parameters set, the operation is 'prepared' and can be instantiated and called
+prepared = TestOperation.with("1", bar: "2").with(baz: 3)
+# => #<TypedOperation::Prepared:0x0000000110a9df38 @keyword_args={:bar=>"2", :baz=>3}, @operation_class=TestOperation, @positional_args=["1"]>
 
-TestOperation.with(foo: "1").with(bar: "2").with(baz: 3).call
-# => "It worked!"
+# A 'prepared' operation can instantiated & called
+prepared.call
+# => "It worked! (1, 2, 3)"
 
-TestOperation.with(foo: "1").with(bar: "2").call(baz: 3)
-# => "It worked!"
+# You can provide additional parameters when calling call on a partially applied operation
+partially_applied.call(baz: 3)
+# => "It worked! (1, 2, 3)"
 
-# > TestOperation.with(foo: "1").with(bar: "2").call
+# Partial application can be done using `.with or `.[]`
+TestOperation.with("1")[bar: "2", baz: 3].call
+# => "It worked! (1, 2, 3)"
+
+# Currying an operation, note that *all required* parameters must be provided an argument in order  
+TestOperation.curry.("1").("2").(3)
+# => "It worked! (1, 2, 3)"
+
+# You can also curry from an already partially applied operation, so you can set optional named parameters first.
+# Note currying won't let you set optional positional parameters.
+partially_applied = TestOperation.with("1")
+partially_applied.curry.("2").(3)
+# => "It worked! (1, 2, 3)"
+
+# > TestOperation.with("1").with(bar: "2").call
 # => Raises an error because it is PartiallyApplied and so can't be called (it is missing required args)
+#      "Cannot call PartiallyApplied operation TestOperation (key: test_operation), are you expecting it to be Prepared? (TypedOperation::MissingParameterError)"
 
-TestOperation.with(foo: "1").with(bar: "2").with(baz: 3).operation
-# same as > TestOperation.new(foo: "1", bar: "2", baz: 3)
-# => <TestOperation:0x000000014a0048a8 @__attributes=#<TestOperation::TypedSchema foo="1" bar="2" baz="3">>
+TestOperation.with("1").with(bar: "2").with(baz: 3).operation
+# same as > TestOperation.new("1", bar: "2", baz: 3)
+# => <TestOperation:0x000000014a0048a8 ...>
 
 # > TestOperation.with(foo: "1").with(bar: "2").operation
 # => Raises an error because it is PartiallyApplied so operation can't be instantiated
+#      "Cannot instantiate Operation TestOperation (key: test_operation), as it is only partially applied. (TypedOperation::MissingParameterError)"
 ```
 
-#### `ApplicationOperation` in a Rails app
+## Usage
+
+### Subclassing `TypedOperation::Base`
+
+Create an operation by subclassing `TypedOperation::Base` and specifying the parameters the operation requires.
+
+The subclass must implement the `#call` method which is where the operations main work is done.
+
+The operation can also implement:
+
+- `#prepare` - called when the operation is initialized, and after the parameters have been set
+
+### Specifying parameters
+
+Parameters are specified using the provided DSL methods (`.positional`, `.named`, and the type constraint `.optional`), 
+or using the underlying `param` method.
+
+#### Positional parameters
+
+`.positional :name, type, *options`
+
+Defines a positional parameter (positional argument passed to the operation when creating it).
+
+A name is provided for the accessor method, and a type constraint is provided for the type of the parameter
+(the type is a type signature compatible with `literal`).
+
+The options are:
+- `default:` - a default value for the parameter (can be a proc or value)
+- `optional:` - a boolean indicating whether the parameter is optional (default: false). Note you may prefer to use the 
+  `.optional` method instead of this option.
+
+Note with positional parameters when arguments are provided to the operation, they are matched in order of definition.
+
+Also note that you cannot define required positional parameters after optional ones.
+
+Eg
+
+```ruby
+class MyOperation < ::TypedOperation::Base
+  positional :name, String
+  positional :age, Integer, default: 0
+  
+  def call
+    puts "Hello #{name} (#{age})"
+  end
+end
+
+MyOperation.new("Steve").call 
+# => "Hello Steve (0)"
+
+MyOperation.with("Steve").call(20)
+# => "Hello Steve (20)"
+```
+
+#### Named parameters
+
+`named :name, type, *options`
+
+Defines a named parameter (keyword argument passed to the operation when creating it).
+
+A name is provided for the accessor method, and a type constraint is provided for the type of the parameter
+
+The options are:
+- `default:` - a default value for the parameter (can be a proc or value)
+- `optional:` - a boolean indicating whether the parameter is optional (default: false). Note you may prefer to use the 
+  `.optional` method instead of this option.
+
+Note with named parameters when arguments are provided to the operation, they are passed as keyword arguments.  
+
+```ruby
+class MyOperation < ::TypedOperation::Base
+  named :name, String
+  named :age, Integer, default: 0
+  
+  def call
+    puts "Hello #{name} (#{age})"
+  end
+end
+
+MyOperation.new(name: "Steve").call 
+# => "Hello Steve (0)"
+
+MyOperation.with(name: "Steve").call(age: 20)
+# => "Hello Steve (20)"
+```
+
+#### Using both positional and named parameters
+
+You can use both positional and named parameters in the same operation.
+
+```ruby
+class MyOperation < ::TypedOperation::Base
+  positional :name, String
+  named :age, Integer, default: 0
+  
+  def call
+    puts "Hello #{name} (#{age})"
+  end
+end
+
+MyOperation.new("Steve").call 
+# => "Hello Steve (0)"
+
+MyOperation.new("Steve", age: 20).call
+# => "Hello Steve (20)"
+
+MyOperation.with("Steve").call(age: 20)
+# => "Hello Steve (20)"
+```
+
+#### Optional parameters
+
+`positional :name, optional(type), *options`
+
+`named :name, optional(type), *options`
+
+Defines an optional parameter (positional or named), by wrapping the type constraint in the `optional` method.
+
+This method effectively makes the type signature a union of the provided type and `NilClass`.
+
+#### Coercing parameters
+
+You can specify a block after a parameter definition to coerce the argument value.
+
+```ruby
+param :name, String, &:to_s
+param :choice, Union(FalseClass, TrueClass) do |v|
+  v == "y"
+end
+```
+
+#### Default values
+
+You can specify a default value for a parameter using the `default:` option.
+
+The default value can be a proc or a value. If the value is specified as `nil` then the default value is literally nil and the parameter is optional.
+
+```ruby
+param :name, String, default: "Steve"
+param :age, Integer, default: -> { rand(100) }
+```
+
+### Calling an operation
+
+An operation can be invoked by:
+
+- instantiating it with at least required params and then calling the `#call` method on the instance
+- once a partially applied operation has been prepared (all required parameters have been set), the call
+  method on TypedOperation::Prepared can be used to instantiate and call the operation.
+- once an operation is curried, the `#call` method on last TypedOperation::Curried in the chain will invoke the operation
+- calling `#call` on a partially applied operation and passing in any remaining required parameters
+
+
+### Partially applying (fixing parameters) on an operation
+
+`.with(...)`: create a partially applied operation with the provided parameters set
+
+**alias: `.[]`**
+
+Note that `.with` can take both positional and keyword arguments, and can be chained.
+
+### Pattern matching on an operation
+
+`TypedOperation::Base` and `TypedOperation::PartiallyApplied` implement `deconstruct` and `deconstruct_keys` methods,
+so they can be pattern matched against.
+
+```ruby
+case MyOperation.new("Steve", age: 20)
+in MyOperation[name, age]
+  puts "Hello #{name} (#{age})"
+end
+
+case MyOperation.new("Steve", age: 20)
+in MyOperation[name:, age: 20]
+  puts "Hello #{name} (#{age})"
+end
+```
+
+### Introspection of parameters & other methods
+
+- `.to_proc`: Get a proc that calls `.call(...)`
+- `#to_proc`: Get a proc that calls the `#call` method on an operation instance
+- `.prepared?`: Check if an operation is prepared
+- `.operation`: Get an operation instance from a Prepared operation. Will raise if called on a PartiallyApplied operation
+
+- `.positional_parameters`: List of the names of the positional parameters, in order
+- `.keyword_parameters`: List of the names of the keyword parameters
+- `.required_positional_parameters`: List of the names of the required positional parameters, in order
+- `.required_keyword_parameters`: List of the names of the required keyword parameters
+- `.optional_positional_parameters`: List of the names of the optional positional parameters, in order
+- `.optional_keyword_parameters`: List of the names of the optional keyword parameters
+
+### Using with Rails
+
+You can use the provided generator to create an `ApplicationOperation` class in your Rails project.
+
+You can then extend this to add extra functionality to all your operations.
 
 This is an example of a `ApplicationOperation` in a Rails app that uses `Dry::Monads`:
 
@@ -66,7 +314,7 @@ This is an example of a `ApplicationOperation` in a Rails app that uses `Dry::Mo
 class ApplicationOperation < ::TypedOperation::Base
   include Dry::Monads[:result, :do]
   
-  param :initiator, ::User, optional: true
+  named :initiator, optional(::User)
 
   private
 
@@ -91,12 +339,13 @@ class ApplicationOperation < ::TypedOperation::Base
   end
 
   def operation_key
-    self.class.operation_key
+    self.class.name
   end
 end
 ```
 
 ## Installation
+
 Add this line to your application's Gemfile:
 
 ```ruby

--- a/README.md
+++ b/README.md
@@ -75,11 +75,11 @@ class ApplicationOperation < ::TypedOperation::Base
   end
 
   def failed_with_value(value, message: "Operation failed", error_code: nil)
-    failed(error_code || self.class.operation_key, message, value)
+    failed(error_code || operation_key, message, value)
   end
 
   def failed_with_message(message, error_code: nil)
-    failed(error_code || self.class.operation_key, message)
+    failed(error_code || operation_key, message)
   end
 
   def failed(error_code, message = "Operation failed", value = nil)
@@ -88,6 +88,10 @@ class ApplicationOperation < ::TypedOperation::Base
 
   def failed_with_code_and_value(error_code, value, message: "Operation failed")
     failed(error_code, message, value)
+  end
+
+  def operation_key
+    self.class.operation_key
   end
 end
 ```

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ This is an example of a `ApplicationOperation` in a Rails app that uses `Dry::Mo
 class ApplicationOperation < ::TypedOperation::Base
   include Dry::Monads[:result, :do]
   
-  param :initiator, ::User, allow_nil: true
+  param :initiator, ::User, optional: true
 
   private
 

--- a/README.md
+++ b/README.md
@@ -8,13 +8,65 @@ Result format of the operation is up to you, but plays nicely with `Dry::Monads`
 
 ### Examples:
 
-A base operation class:
+#### A simple operation:
 
 ```ruby
+class TestOperation < ::TypedOperation::Base
+  param :foo, String
+  param :bar, String
+  param :baz, String do |value|
+    value.to_s
+  end
+
+  def prepare
+    # to setup (optional)
+    puts "lets go!"
+  end
+  
+  def call
+    "It worked!"
+  end
+end
+```
+
+```ruby
+TestOperation.(foo: "1", bar: "2", baz: 3)
+# => "It worked!"
+
+TestOperation.with(foo: "1").with(bar: "2")
+# => #<TypedOperation::PartiallyApplied:0x000000014a655310 @applied_args={:foo=>"1", :bar=>"2"}, @operation=TestOperation>
+
+TestOperation.with(foo: "1").with(bar: "2").with(baz: 3)
+# => <TypedOperation::Prepared:0x000000012dac6498 @applied_args={:foo=>"1", :bar=>"2", :baz=>3}, @operation=TestOperation>
+
+TestOperation.with(foo: "1").with(bar: "2").with(baz: 3).call
+# => "It worked!"
+
+TestOperation.with(foo: "1").with(bar: "2").call(baz: 3)
+# => "It worked!"
+
+# > TestOperation.with(foo: "1").with(bar: "2").call
+# => Raises an error because it is PartiallyApplied and so can't be called (it is missing required args)
+
+TestOperation.with(foo: "1").with(bar: "2").with(baz: 3).operation
+# same as > TestOperation.new(foo: "1", bar: "2", baz: 3)
+# => <TestOperation:0x000000014a0048a8 @__attributes=#<TestOperation::TypedSchema foo="1" bar="2" baz="3">>
+
+# > TestOperation.with(foo: "1").with(bar: "2").operation
+# => Raises an error because it is PartiallyApplied so operation can't be instantiated
+```
+
+#### `ApplicationOperation` in a Rails app
+
+This is an example of a `ApplicationOperation` in a Rails app that uses `Dry::Monads`:
+
+```ruby
+# frozen_string_literal: true
+
 class ApplicationOperation < ::TypedOperation::Base
   include Dry::Monads[:result, :do]
   
-  param :initiator, ::RegisteredUser, allow_nil: true
+  param :initiator, ::User, allow_nil: true
 
   private
 
@@ -38,44 +90,6 @@ class ApplicationOperation < ::TypedOperation::Base
     failed(error_code, message, value)
   end
 end
-
-```
-
-A simple operation:
-
-```ruby
-class TestOperation < ::ApplicationOperation
-  param :foo, String
-  param :bar, String
-  param :baz, String, convert: true
-
-  def prepare
-    # to setup (optional)
-    puts "lets go!"
-  end
-  
-  def call
-    succeeded("It worked!")
-    # failed_with_message("It failed!")
-  end
-end
-```
-
-```ruby
-TestOperation.(foo: "1", bar: "2", baz: 3)
-# => Success("It worked!")
-
-TestOperation.with(foo: "1").with(bar: "2")
-# => #<TypedOperation::PartiallyApplied:0x000000014a655310 @applied_args={:foo=>"1", :bar=>"2"}, @operation=TestOperation>
-
-TestOperation.with(foo: "1").with(bar: "2").with(baz: 3)
-# => <TypedOperation::Prepared:0x000000012dac6498 @applied_args={:foo=>"1", :bar=>"2", :baz=>3}, @operation=TestOperation>
-
-TestOperation.with(foo: "1").with(bar: "2").with(baz: 3).call
-# => Success("It worked!")
-
-TestOperation.with(foo: "1").with(bar: "2").with(baz: 3).operation
-# => <TestOperation:0x000000014a0048a8 @__attributes=#<TestOperation::TypedSchema foo="1" bar="2" baz="3">>
 ```
 
 ## Installation
@@ -125,7 +139,13 @@ The default path is `app/operations`.
 The generator will also create a test file.
 
 ## Contributing
-Contribution directions go here.
+
+Bug reports and pull requests are welcome on GitHub at https://github.com/stevegeek/typed_operation. This project is intended to be a safe, welcoming space for collaboration, and contributors are expected to adhere to the [code of conduct](https://github.com/stevegeek/typed_operation/blob/master/CODE_OF_CONDUCT.md).
 
 ## License
+
 The gem is available as open source under the terms of the [MIT License](https://opensource.org/licenses/MIT).
+
+## Code of Conduct
+
+Everyone interacting in the TypedOperation project's codebases, issue trackers, chat rooms and mailing lists is expected to follow the [code of conduct](https://github.com/stevegeek/typed_operation/blob/master/CODE_OF_CONDUCT.md).

--- a/lib/generators/templates/operation.rb
+++ b/lib/generators/templates/operation.rb
@@ -4,8 +4,9 @@
 module <%= namespace_name %>
   class <%= name %> < ::ApplicationOperation
     # Replace with implementation...
-    param :required_param, String
-    param :an_optional_param, Integer, allow_nil: true do |value|
+    positional :required_positional_param, String
+    named :required_named_param, String
+    named :an_optional_param, Integer, optional: true do |value|
      value.to_i
     end
 
@@ -22,8 +23,11 @@ end
 <% else %>
 class <%= name %> < ::ApplicationOperation
   # Replace with implementation...
-  param :required_param, String
-  param :an_optional_param, Integer, convert: true, allow_nil: true
+  positional :required_positional_param, String
+  named :required_named_param, String
+  named :an_optional_param, Integer, optional: true do |value|
+    value.to_i
+  end
 
   def prepare
     # Prepare...

--- a/lib/generators/templates/operation.rb
+++ b/lib/generators/templates/operation.rb
@@ -5,7 +5,9 @@ module <%= namespace_name %>
   class <%= name %> < ::ApplicationOperation
     # Replace with implementation...
     param :required_param, String
-    param :an_optional_param, Integer, convert: true, allow_nil: true
+    param :an_optional_param, Integer, allow_nil: true do |value|
+     value.to_i
+    end
 
     def prepare
       # Prepare...

--- a/lib/typed_operation.rb
+++ b/lib/typed_operation.rb
@@ -1,5 +1,6 @@
 require "typed_operation/version"
 require "typed_operation/railtie" if defined?(Rails::Railtie)
+require "typed_operation/nilable_type"
 require "typed_operation/base"
 require "typed_operation/partially_applied"
 require "typed_operation/prepared"

--- a/lib/typed_operation.rb
+++ b/lib/typed_operation.rb
@@ -1,3 +1,7 @@
+if Gem::Version.new(RUBY_VERSION) < Gem::Version.new("3.2.0")
+  require "polyfill-data"
+end
+
 require "typed_operation/version"
 require "typed_operation/railtie" if defined?(Rails::Railtie)
 require "typed_operation/nilable_type"

--- a/lib/typed_operation.rb
+++ b/lib/typed_operation.rb
@@ -2,6 +2,7 @@ require "typed_operation/version"
 require "typed_operation/railtie" if defined?(Rails::Railtie)
 require "typed_operation/nilable_type"
 require "typed_operation/attribute_builder"
+require "typed_operation/curried"
 require "typed_operation/base"
 require "typed_operation/partially_applied"
 require "typed_operation/prepared"

--- a/lib/typed_operation.rb
+++ b/lib/typed_operation.rb
@@ -1,6 +1,7 @@
 require "typed_operation/version"
 require "typed_operation/railtie" if defined?(Rails::Railtie)
 require "typed_operation/nilable_type"
+require "typed_operation/attribute_builder"
 require "typed_operation/base"
 require "typed_operation/partially_applied"
 require "typed_operation/prepared"

--- a/lib/typed_operation.rb
+++ b/lib/typed_operation.rb
@@ -1,11 +1,13 @@
 require "typed_operation/version"
-require "typed_operation/railtie"
+require "typed_operation/railtie" if defined?(Rails::Railtie)
 require "typed_operation/base"
 require "typed_operation/partially_applied"
 require "typed_operation/prepared"
 
 module TypedOperation
   class InvalidOperationError < StandardError; end
+
   class MissingParameterError < ArgumentError; end
+
   class ParameterError < TypeError; end
 end

--- a/lib/typed_operation/attribute_builder.rb
+++ b/lib/typed_operation/attribute_builder.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+module TypedOperation
+  class AttributeBuilder
+    def initialize(typed_operation, parameter_name, type_signature, options)
+      @typed_operation = typed_operation
+      @name = parameter_name
+      @signature = type_signature
+      @optional = options[:optional]
+      @positional = options[:positional]
+      @reader = options[:reader] || :public
+      @default_key = options.key?(:default)
+      @default = options[:default]
+
+      prepare_type_signature_for_literal
+    end
+
+    def define(&converter)
+      @typed_operation.attribute(
+        @name,
+        @signature,
+        default: default_value_for_literal,
+        positional: @positional,
+        reader: @reader,
+        &converter
+      )
+    end
+
+    private
+
+    def prepare_type_signature_for_literal
+      @signature = NilableType.new(@signature) if needs_to_be_nilable?
+      union_with_nil_to_support_nil_default
+      validate_positional_order_params! if @positional
+    end
+
+    # If already wrapped in a Nilable then don't wrap again
+    def needs_to_be_nilable?
+      @optional && !type_nilable?
+    end
+
+    def type_nilable?
+      @signature.is_a?(NilableType)
+    end
+
+    def union_with_nil_to_support_nil_default
+      @signature = Literal::Union.new(@signature, NilClass) if has_default_value_nil?
+    end
+
+    def has_default_value_nil?
+      default_provided? && @default.nil?
+    end
+
+    def validate_positional_order_params!
+      # Optional ones can always be added after required ones, or before any others, but required ones must be first
+      unless type_nilable? || @typed_operation.optional_positional_parameters.empty?
+        raise ParameterError, "Cannot define required positional parameter '#{@name}' after optional positional parameters"
+      end
+    end
+
+    def default_provided?
+      @default_key
+    end
+
+    def default_value_for_literal
+      if has_default_value_nil? || type_nilable?
+        -> {}
+      else
+        @default
+      end
+    end
+  end
+end

--- a/lib/typed_operation/base.rb
+++ b/lib/typed_operation/base.rb
@@ -9,11 +9,11 @@ module TypedOperation
         new(...).call
       end
 
-      def curry(...)
-        PartiallyApplied.new(self, ...).curry
+      def with(...)
+        PartiallyApplied.new(self, ...).with
       end
-      alias_method :[], :curry
-      alias_method :with, :curry
+      alias_method :[], :with
+      alias_method :curry, :with
 
       def to_proc
         method(:call).to_proc

--- a/lib/typed_operation/base.rb
+++ b/lib/typed_operation/base.rb
@@ -81,11 +81,5 @@ module TypedOperation
     def deconstruct_keys(_keys)
       attributes.to_h
     end
-
-    private
-
-    def operation_key
-      self.class.operation_key
-    end
   end
 end

--- a/lib/typed_operation/base.rb
+++ b/lib/typed_operation/base.rb
@@ -78,8 +78,9 @@ module TypedOperation
       attributes.values
     end
 
-    def deconstruct_keys(_keys)
-      attributes.to_h
+    def deconstruct_keys(keys)
+      h = attributes.to_h
+      keys ? h.slice(*keys) : h
     end
   end
 end

--- a/lib/typed_operation/base.rb
+++ b/lib/typed_operation/base.rb
@@ -19,11 +19,7 @@ module TypedOperation
         method(:call).to_proc
       end
 
-      def operation_key
-        name.underscore.to_sym
-      end
-
-      # Medhod to define parameters for your operation.
+      # Method to define parameters for your operation.
 
       # Parameter for keyword argument, or a positional argument if you use positional: true
       # Required, but you can set a default or use optional: true if you want optional

--- a/lib/typed_operation/base.rb
+++ b/lib/typed_operation/base.rb
@@ -23,23 +23,50 @@ module TypedOperation
         name.underscore.to_sym
       end
 
-      # property are required by default, you can fall back to attribute or set allow_nil: true if you want optional
-      def param(name, signature = :any, **options, &converter)
-        attribute(
-          name,
-          prepare_signature(signature, options),
-          default: prepare_default_value_for(name, options),
-          &converter
-        )
+      # Parameter for positional argument
+      def positional(name, signature = :any, **options, &converter)
+        param(name, signature, **options.merge(positional: true), &converter)
       end
 
-      def required_params
-        @required ||= @literal_attributes.filter_map do |name, attribute|
-          name if required_attribute?(attribute)
-        end
+      # Parameter for a keyword or named argument
+      def named(name, signature = :any, **options, &converter)
+        param(name, signature, **options.merge(positional: false), &converter)
+      end
+
+      # Parameter for keyword argument, or a positional argument if you use positional: true
+      # Required, but you can set a default or use allow_nil: true if you want optional
+      def param(name, signature = :any, **options, &converter)
+        define_literal_attribute(name, signature, options, &converter)
+      end
+
+      # Introspection methods
+
+      def positional_parameters
+        literal_attributes.filter_map { |name, attribute| name if attribute.positional? }
+      end
+
+      def keyword_parameters
+        literal_attributes.filter_map { |name, attribute| name unless attribute.positional? }
+      end
+
+      def required_positional_parameters
+        required_parameters.filter_map { |name, attribute| name if attribute.positional? }
+      end
+
+      def required_keyword_parameters
+        required_parameters.filter_map { |name, attribute| name unless attribute.positional? }
       end
 
       private
+
+      def define_literal_attribute(name, signature, options, &converter)
+        positional = options[:positional]
+        reader = options[:reader] || :public
+        type_signature = prepare_signature(signature, options)
+        default_val_or_proc = prepare_default_value_for(name, options)
+
+        attribute(name, type_signature, default: default_val_or_proc, positional: positional, reader: reader, &converter)
+      end
 
       def prepare_signature(signature, options)
         allows_nil?(options) ? Literal::Union.new(signature, NilClass) : signature
@@ -55,6 +82,12 @@ module TypedOperation
 
       def allows_nil?(options)
         options[:allow_nil] == true || (options.key?(:default) && options[:default].nil?)
+      end
+
+      def required_parameters
+        @required_parameters ||= literal_attributes.filter do |name, attribute|
+          required_attribute?(attribute)
+        end
       end
 
       def required_attribute?(attribute)

--- a/lib/typed_operation/base.rb
+++ b/lib/typed_operation/base.rb
@@ -23,6 +23,8 @@ module TypedOperation
         name.underscore.to_sym
       end
 
+      # Alternative DSL
+
       # Parameter for positional argument
       def positional(name, signature = :any, **options, &converter)
         param(name, signature, **options.merge(positional: true), &converter)
@@ -33,8 +35,13 @@ module TypedOperation
         param(name, signature, **options.merge(positional: false), &converter)
       end
 
+      # Wrap a type signature in a NilableType meaning it is optional to TypedOperation
+      def optional(type_signature)
+        NilableType.new(type_signature)
+      end
+
       # Parameter for keyword argument, or a positional argument if you use positional: true
-      # Required, but you can set a default or use allow_nil: true if you want optional
+      # Required, but you can set a default or use optional: true if you want optional
       def param(name, signature = :any, **options, &converter)
         define_literal_attribute(name, signature, options, &converter)
       end

--- a/lib/typed_operation/base.rb
+++ b/lib/typed_operation/base.rb
@@ -77,13 +77,9 @@ module TypedOperation
       private
 
       def required_parameters
-        @required_parameters ||= literal_attributes.filter do |name, attribute|
-          required_attribute?(attribute)
+        literal_attributes.filter do |name, attribute|
+          attribute.default.nil? # Any optional parameters will have a default value/proc in their Literal::Attribute
         end
-      end
-
-      def required_attribute?(attribute)
-        attribute.default.nil?
       end
     end
 

--- a/lib/typed_operation/base.rb
+++ b/lib/typed_operation/base.rb
@@ -9,8 +9,8 @@ module TypedOperation
         new(...).call
       end
 
-      def curry(**args)
-        PartiallyApplied.new(self, **args).curry
+      def curry(...)
+        PartiallyApplied.new(self, ...).curry
       end
       alias_method :[], :curry
       alias_method :with, :curry

--- a/lib/typed_operation/base.rb
+++ b/lib/typed_operation/base.rb
@@ -42,7 +42,7 @@ module TypedOperation
       private
 
       def prepare_signature(signature, options)
-        allows_nil?(options) ? Literal::Types::UnionType.new(signature, NilClass) : signature
+        allows_nil?(options) ? Literal::Union.new(signature, NilClass) : signature
       end
 
       def prepare_default_value_for(name, options)

--- a/lib/typed_operation/base.rb
+++ b/lib/typed_operation/base.rb
@@ -13,7 +13,10 @@ module TypedOperation
         PartiallyApplied.new(self, ...).with
       end
       alias_method :[], :with
-      alias_method :curry, :with
+
+      def curry
+        Curried.new(self)
+      end
 
       def to_proc
         method(:call).to_proc

--- a/lib/typed_operation/curried.rb
+++ b/lib/typed_operation/curried.rb
@@ -9,8 +9,7 @@ module TypedOperation
 
     def call(arg)
       raise ArgumentError, "A prepared operation should not be curried" if @partial_operation.prepared?
-      # apply arg to next required parameter and return a new curried operation
-      # when all required parameters are applied, invoke operation
+
       next_partially_applied = if next_parameter_positional?
         @partial_operation.with(arg)
       else

--- a/lib/typed_operation/curried.rb
+++ b/lib/typed_operation/curried.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+module TypedOperation
+  class Curried
+    def initialize(operation_class, partial_operation = nil)
+      @operation_class = operation_class
+      @partial_operation = partial_operation || operation_class.with
+    end
+
+    def call(arg)
+      raise ArgumentError, "A prepared operation should not be curried" if @partial_operation.prepared?
+      # apply arg to next required parameter and return a new curried operation
+      # when all required parameters are applied, invoke operation
+      next_partially_applied = if next_parameter_positional?
+        @partial_operation.with(arg)
+      else
+        @partial_operation.with(next_keyword_parameter => arg)
+      end
+      if next_partially_applied.prepared?
+        next_partially_applied.call
+      else
+        Curried.new(@operation_class, next_partially_applied)
+      end
+    end
+
+    def to_proc
+      method(:call).to_proc
+    end
+
+    private
+
+    def next_keyword_parameter
+      remaining = @operation_class.required_keyword_parameters - @partial_operation.keyword_args.keys
+      remaining.first
+    end
+
+    def next_parameter_positional?
+      @partial_operation.positional_args.size < @operation_class.required_positional_parameters.size
+    end
+  end
+end

--- a/lib/typed_operation/nilable_type.rb
+++ b/lib/typed_operation/nilable_type.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+require "literal"
+
+module TypedOperation
+  class NilableType < Literal::Union
+    def initialize(*types)
+      @types = types + [NilClass]
+    end
+  end
+end

--- a/lib/typed_operation/partially_applied.rb
+++ b/lib/typed_operation/partially_applied.rb
@@ -2,22 +2,22 @@
 
 module TypedOperation
   class PartiallyApplied
-    def initialize(operation_class, **applied_args)
+    def initialize(operation_class, *positional_args, **keyword_args)
       @operation_class = operation_class
-      @applied_args = applied_args
+      @positional_args = positional_args
+      @keyword_args = keyword_args
     end
 
-    def curry(**params)
-      all_args = @applied_args.merge(params)
-      # check if required attrs are in @applied_args
-      required_keys = @operation_class.required_params
-      missing_keys = required_keys - all_args.keys
+    def curry(*positional, **keyword)
+      all_positional = @positional_args + positional
+      all_kw_args = @keyword_args.merge(keyword)
 
-      if missing_keys.size > 0
-        # Partially apply the arguments
-        PartiallyApplied.new(@operation_class, **all_args)
+      validate_positional_arg_count!(all_positional.size)
+
+      if partially_applied?(all_positional, all_kw_args)
+        PartiallyApplied.new(operation_class, *all_positional, **all_kw_args)
       else
-        Prepared.new(@operation_class, **all_args)
+        Prepared.new(operation_class, *all_positional, **all_kw_args)
       end
     end
     alias_method :[], :curry
@@ -29,16 +29,47 @@ module TypedOperation
       raise MissingParameterError, "Cannot call PartiallyApplied operation #{operation_class.name} (key: #{operation_class.operation_key}), are you expecting it to be Prepared?"
     end
 
-    def deconstruct
-      @applied_args.values
+    def to_proc
+      method(:call).to_proc
     end
 
-    def deconstruct_keys(_keys)
-      @applied_args.dup
+    def deconstruct
+      @positional_args + @keyword_args.values
+    end
+
+    def deconstruct_keys(keys)
+      h = @keyword_args.dup
+      @positional_args.each_with_index { |v, i| h[positional_parameters[i]] = v }
+      keys ? h.slice(*keys) : h
     end
 
     private
 
     attr_reader :operation_class
+
+    def required_positional_parameters
+      @required_positional_parameters ||= operation_class.required_positional_parameters
+    end
+
+    def required_keyword_parameters
+      @required_keyword_parameters ||= operation_class.required_keyword_parameters
+    end
+
+    def positional_parameters
+      @positional_parameters ||= operation_class.positional_parameters
+    end
+
+    def validate_positional_arg_count!(count)
+      if count > positional_parameters.size
+        raise ArgumentError, "Too many positional arguments provided for #{operation_class.name} (key: #{operation_class.operation_key})"
+      end
+    end
+
+    def partially_applied?(all_positional, all_kw_args)
+      missing_positional = required_positional_parameters.size - all_positional.size
+      missing_keys = required_keyword_parameters - all_kw_args.keys
+
+      missing_positional > 0 || missing_keys.size > 0
+    end
   end
 end

--- a/lib/typed_operation/partially_applied.rb
+++ b/lib/typed_operation/partially_applied.rb
@@ -26,11 +26,11 @@ module TypedOperation
     def call(...)
       prepared = with(...)
       return prepared.operation.call if prepared.is_a?(Prepared)
-      raise MissingParameterError, "Cannot call PartiallyApplied operation #{operation_class.name} (key: #{operation_class.operation_key}), are you expecting it to be Prepared?"
+      raise MissingParameterError, "Cannot call PartiallyApplied operation #{operation_class.name} (key: #{operation_class.name}), are you expecting it to be Prepared?"
     end
 
     def operation
-      raise MissingParameterError, "Cannot instantiate Operation #{operation_class.name} (key: #{operation_class.operation_key}), as it is only partially applied."
+      raise MissingParameterError, "Cannot instantiate Operation #{operation_class.name} (key: #{operation_class.name}), as it is only partially applied."
     end
 
     def to_proc
@@ -65,7 +65,7 @@ module TypedOperation
 
     def validate_positional_arg_count!(count)
       if count > positional_parameters.size
-        raise ArgumentError, "Too many positional arguments provided for #{operation_class.name} (key: #{operation_class.operation_key})"
+        raise ArgumentError, "Too many positional arguments provided for #{operation_class.name} (key: #{operation_class.name})"
       end
     end
 

--- a/lib/typed_operation/partially_applied.rb
+++ b/lib/typed_operation/partially_applied.rb
@@ -26,7 +26,7 @@ module TypedOperation
     def call(...)
       prepared = curry(...)
       return prepared.operation.call if prepared.is_a?(Prepared)
-      raise MissingParameterError, "Cannot call PartiallyApplied operation #{@operation_class.name} (key: #{@operation_class.operation_key}), are you expecting it to be Prepared?"
+      raise MissingParameterError, "Cannot call PartiallyApplied operation #{operation_class.name} (key: #{operation_class.operation_key}), are you expecting it to be Prepared?"
     end
 
     def deconstruct

--- a/lib/typed_operation/partially_applied.rb
+++ b/lib/typed_operation/partially_applied.rb
@@ -9,8 +9,8 @@ module TypedOperation
     end
 
     def with(*positional, **keyword)
-      all_positional = @positional_args + positional
-      all_kw_args = @keyword_args.merge(keyword)
+      all_positional = positional_args + positional
+      all_kw_args = keyword_args.merge(keyword)
 
       validate_positional_arg_count!(all_positional.size)
 
@@ -21,7 +21,10 @@ module TypedOperation
       end
     end
     alias_method :[], :with
-    alias_method :curry, :with
+
+    def curry
+      Curried.new(operation_class, self)
+    end
 
     def call(...)
       prepared = with(...)
@@ -33,19 +36,25 @@ module TypedOperation
       raise MissingParameterError, "Cannot instantiate Operation #{operation_class.name} (key: #{operation_class.name}), as it is only partially applied."
     end
 
+    def prepared?
+      false
+    end
+
     def to_proc
       method(:call).to_proc
     end
 
     def deconstruct
-      @positional_args + @keyword_args.values
+      positional_args + keyword_args.values
     end
 
     def deconstruct_keys(keys)
-      h = @keyword_args.dup
-      @positional_args.each_with_index { |v, i| h[positional_parameters[i]] = v }
+      h = keyword_args.dup
+      positional_args.each_with_index { |v, i| h[positional_parameters[i]] = v }
       keys ? h.slice(*keys) : h
     end
+
+    attr_reader :positional_args, :keyword_args
 
     private
 

--- a/lib/typed_operation/partially_applied.rb
+++ b/lib/typed_operation/partially_applied.rb
@@ -2,25 +2,22 @@
 
 module TypedOperation
   class PartiallyApplied
-    def initialize(operation, **applied_args)
-      @operation = operation
+    def initialize(operation_class, **applied_args)
+      @operation_class = operation_class
       @applied_args = applied_args
     end
 
     def curry(**params)
       all_args = @applied_args.merge(params)
       # check if required attrs are in @applied_args
-      required_keys = @operation.attribute_names.select do |name|
-        meta = @operation.attribute_metadata(name)
-        meta[:required] != false && !meta[:typed_attribute_options].key?(:default)
-      end
+      required_keys = @operation_class.required_params
       missing_keys = required_keys - all_args.keys
 
       if missing_keys.size > 0
         # Partially apply the arguments
-        PartiallyApplied.new(@operation, **all_args)
+        PartiallyApplied.new(@operation_class, **all_args)
       else
-        Prepared.new(@operation, **all_args)
+        Prepared.new(@operation_class, **all_args)
       end
     end
     alias_method :[], :curry
@@ -29,7 +26,11 @@ module TypedOperation
     def call(...)
       prepared = curry(...)
       return prepared.operation.call if prepared.is_a?(Prepared)
-      raise TypedOperation::MissingParameterError, "Cannot call PartiallyApplied operation #{@operation.name} (key: #{@operation.operation_key}), are you expecting it to be Prepared?"
+      raise MissingParameterError, "Cannot call PartiallyApplied operation #{@operation_class.name} (key: #{@operation_class.operation_key}), are you expecting it to be Prepared?"
     end
+
+    private
+
+    attr_reader :operation_class
   end
 end

--- a/lib/typed_operation/partially_applied.rb
+++ b/lib/typed_operation/partially_applied.rb
@@ -29,6 +29,10 @@ module TypedOperation
       raise MissingParameterError, "Cannot call PartiallyApplied operation #{operation_class.name} (key: #{operation_class.operation_key}), are you expecting it to be Prepared?"
     end
 
+    def operation
+      raise MissingParameterError, "Cannot instantiate Operation #{operation_class.name} (key: #{operation_class.operation_key}), as it is only partially applied."
+    end
+
     def to_proc
       method(:call).to_proc
     end

--- a/lib/typed_operation/partially_applied.rb
+++ b/lib/typed_operation/partially_applied.rb
@@ -8,7 +8,7 @@ module TypedOperation
       @keyword_args = keyword_args
     end
 
-    def curry(*positional, **keyword)
+    def with(*positional, **keyword)
       all_positional = @positional_args + positional
       all_kw_args = @keyword_args.merge(keyword)
 
@@ -20,11 +20,11 @@ module TypedOperation
         Prepared.new(operation_class, *all_positional, **all_kw_args)
       end
     end
-    alias_method :[], :curry
-    alias_method :with, :curry
+    alias_method :[], :with
+    alias_method :curry, :with
 
     def call(...)
-      prepared = curry(...)
+      prepared = with(...)
       return prepared.operation.call if prepared.is_a?(Prepared)
       raise MissingParameterError, "Cannot call PartiallyApplied operation #{operation_class.name} (key: #{operation_class.operation_key}), are you expecting it to be Prepared?"
     end

--- a/lib/typed_operation/prepared.rb
+++ b/lib/typed_operation/prepared.rb
@@ -5,5 +5,9 @@ module TypedOperation
     def operation
       operation_class.new(*@positional_args, **@keyword_args)
     end
+
+    def prepared?
+      true
+    end
   end
 end

--- a/lib/typed_operation/prepared.rb
+++ b/lib/typed_operation/prepared.rb
@@ -3,7 +3,7 @@
 module TypedOperation
   class Prepared < PartiallyApplied
     def operation
-      operation_class.new(**@applied_args)
+      operation_class.new(*@positional_args, **@keyword_args)
     end
   end
 end

--- a/lib/typed_operation/prepared.rb
+++ b/lib/typed_operation/prepared.rb
@@ -3,7 +3,7 @@
 module TypedOperation
   class Prepared < PartiallyApplied
     def operation
-      @operation.new(**@applied_args)
+      operation_class.new(**@applied_args)
     end
   end
 end

--- a/test/lib/generators/typed_operation_generator_test.rb
+++ b/test/lib/generators/typed_operation_generator_test.rb
@@ -26,7 +26,7 @@ class OperationGeneratorTest < Rails::Generators::TestCase
     assert_file "app/operations/test_operation.rb" do |content|
       assert_not_includes("module App::Operations", content)
       assert_match(/class TestOperation < ::ApplicationOperation/, content)
-      assert_match(/param :required_param, String/, content)
+      assert_match(/positional :required_positional_param, String/, content)
     end
 
     assert_file "test/operations/test_operation_test.rb" do |content|
@@ -41,7 +41,7 @@ class OperationGeneratorTest < Rails::Generators::TestCase
     assert_file "app/things/stuff/test_path_operation.rb" do |content|
       assert_match(/module Stuff/, content)
       assert_match(/class TestPathOperation < ::ApplicationOperation/, content)
-      assert_match(/param :an_optional_param, Integer, allow_nil: true do/, content)
+      assert_match(/named :an_optional_param, Integer, optional: true do/, content)
     end
 
     assert_file "test/things/stuff/test_path_operation_test.rb" do |content|

--- a/test/lib/generators/typed_operation_generator_test.rb
+++ b/test/lib/generators/typed_operation_generator_test.rb
@@ -41,7 +41,7 @@ class OperationGeneratorTest < Rails::Generators::TestCase
     assert_file "app/things/stuff/test_path_operation.rb" do |content|
       assert_match(/module Stuff/, content)
       assert_match(/class TestPathOperation < ::ApplicationOperation/, content)
-      assert_match(/param :an_optional_param, Integer, convert: true, allow_nil: true/, content)
+      assert_match(/param :an_optional_param, Integer, allow_nil: true do/, content)
     end
 
     assert_file "test/things/stuff/test_path_operation_test.rb" do |content|

--- a/test/typed_operation_test.rb
+++ b/test/typed_operation_test.rb
@@ -18,7 +18,8 @@ class TypedOperationTest < ActiveSupport::TestCase
     end
 
     param :with_default, String, default: "qux"
-    param :can_be_nil, Integer, allow_nil: true, default: nil
+    param :can_be_nil, Integer, allow_nil: true
+    param :can_also_be_nil, TypedOperation::Base, default: nil
 
     def prepare
       @local_var = 123
@@ -46,6 +47,11 @@ class TypedOperationTest < ActiveSupport::TestCase
     assert_equal "qux", operation.with_default
   end
 
+  def test_operation_supports_nil_default_values
+    operation = TestOperation.new(foo: "1", bar: "2", baz: "3")
+    assert_nil operation.can_also_be_nil
+  end
+
   def test_operation_supports_nil_params
     operation = TestOperation.new(foo: "1", bar: "2", baz: "3")
     assert_nil operation.can_be_nil
@@ -54,6 +60,16 @@ class TypedOperationTest < ActiveSupport::TestCase
   def test_operation_sets_nilable_params
     operation = TestOperation.new(foo: "1", bar: "2", baz: "3", can_be_nil: 123)
     assert_equal 123, operation.can_be_nil
+  end
+
+  def test_operation_params_type_can_be_arbitrary_class
+    some_instance = TestOperation.new(foo: "1", bar: "2", baz: "3")
+    operation = TestOperation.new(foo: "1", bar: "2", baz: "3", can_also_be_nil: some_instance)
+    assert_equal some_instance, operation.can_also_be_nil
+  end
+
+  def test_operation_params_type_can_be_arbitrary_class_raises
+    assert_raises(TypeError) { TestOperation.new(foo: "1", bar: "2", baz: "3", can_also_be_nil: Set.new) }
   end
 
   def test_operation_is_prepared

--- a/test/typed_operation_test.rb
+++ b/test/typed_operation_test.rb
@@ -133,14 +133,15 @@ class TypedOperationTest < ActiveSupport::TestCase
   def test_operation_instance_supports_pattern_matching_params
     operation = TestOperation.new(foo: "1", bar: "2", baz: "3", can_be_nil: 5)
     assert_equal ["1", "2", "3", "qux", 5, nil], operation.deconstruct
-    assert_equal({foo: "1", bar: "2", baz: "3", with_default: "qux", can_be_nil: 5, can_also_be_nil: nil}, operation.deconstruct_keys(%i[foo bar baz]))
+    assert_equal({foo: "1", bar: "2", baz: "3", with_default: "qux", can_be_nil: 5, can_also_be_nil: nil}, operation.deconstruct_keys(nil))
+    assert_equal({foo: "1", can_be_nil: 5}, operation.deconstruct_keys(%i[foo can_be_nil]))
     case operation
     in TestOperation[foo: foo, with_default: default, **rest]
       assert_equal "1", foo
       assert_equal "qux", default
       assert_equal({bar: "2", baz: "3", can_be_nil: 5, can_also_be_nil: nil}, rest)
     else
-      raise "Pattern match failed"
+      raise Minitest::UnexpectedError, "Pattern match failed"
     end
     case operation
     in String => foo, String => bar, String => baz, String => with_default, Integer => can_be_nil, NilClass => can_also_be_nil
@@ -151,7 +152,7 @@ class TypedOperationTest < ActiveSupport::TestCase
       assert_equal 5, can_be_nil
       assert_nil can_also_be_nil
     else
-      raise "Pattern match failed"
+      raise Minitest::UnexpectedError, "Pattern match failed"
     end
   end
 
@@ -163,26 +164,27 @@ class TypedOperationTest < ActiveSupport::TestCase
       assert_equal "2", bar
       assert_equal({}, rest)
     else
-      raise "Pattern match failed"
+      raise Minitest::UnexpectedError, "Pattern match failed"
     end
     case partially_applied
     in String => foo, String => bar
       assert_equal "1", foo
       assert_equal "2", bar
     else
-      raise "Pattern match failed"
+      raise Minitest::UnexpectedError, "Pattern match failed"
     end
   end
 
   def test_operation_prepared_supports_pattern_matching_currently_applied_params
     prepared = TestOperation.with(foo: "1", bar: "2", baz: "3")
+
     case prepared
     in TypedOperation::Prepared[foo: foo, bar: bar, **rest]
       assert_equal "1", foo
       assert_equal "2", bar
       assert_equal({baz: "3"}, rest)
     else
-      raise "Pattern match failed"
+      raise Minitest::UnexpectedError, "Pattern match failed"
     end
     case prepared
     in String => foo, String => bar, String => baz
@@ -190,7 +192,7 @@ class TypedOperationTest < ActiveSupport::TestCase
       assert_equal "2", bar
       assert_equal "3", baz
     else
-      raise "Pattern match failed"
+      raise Minitest::UnexpectedError, "Pattern match failed"
     end
   end
 end

--- a/test/typed_operation_test.rb
+++ b/test/typed_operation_test.rb
@@ -100,10 +100,6 @@ class TypedOperationTest < ActiveSupport::TestCase
     assert_equal %i[kw2], TestKeywordAndPositionalOperation.optional_keyword_parameters
   end
 
-  def test_class_method_operation_key
-    assert_equal :"typed_operation_test/test_operation", TestOperation.operation_key
-  end
-
   def test_operation_acts_as_proc
     assert_equal ["first!", "second!"], ["first", "second"].map(&TestPositionalOperation)
   end

--- a/test/typed_operation_test.rb
+++ b/test/typed_operation_test.rb
@@ -95,6 +95,22 @@ class TypedOperationTest < ActiveSupport::TestCase
     assert_equal ["first!", "second!"], ["first", "second"].map(&TestPositionalOperation)
   end
 
+  def test_operation_raises_on_invalid_positional_params
+    assert_raises do
+      Class.new(::TypedOperation::Base) do
+        # This is invalid, because positional params can't be optional before required ones
+        positional :first, String, optional: true
+        positional :second, String
+      end
+
+      Class.new(::TypedOperation::Base) do
+        # This is invalid, because positional params can't be optional before required ones
+        positional :first, optional(String)
+        positional :second, String
+      end
+    end
+  end
+
   def test_operation_acts_as_proc_on_partially_applied
     curried_operation = TestPositionalOperation.with("first")
     assert_equal ["first/second", "first/third"], ["second", "third"].map(&curried_operation)

--- a/test/typed_operation_test.rb
+++ b/test/typed_operation_test.rb
@@ -22,13 +22,26 @@ class TypedOperationTest < ActiveSupport::TestCase
   end
 
   class TestKeywordAndPositionalOperation < ::TypedOperation::Base
-    positional :pos1, String
-    positional :pos2, String, default: "pos2"
-    named :kw1, String
-    named :kw2, String, default: "kw2"
+    param :pos1, String, positional: true
+    param :pos2, String, default: "pos2", positional: true
+    param :kw1, String
+    param :kw2, String, default: "kw2"
 
     def call
       "#{pos1}/#{pos2}/#{kw1}/#{kw2}"
+    end
+  end
+
+  class TestAlternativeDslOperation < ::TypedOperation::Base
+    positional :pos1, String
+    positional :pos2, String, default: "pos2"
+    positional :pos3, optional(String)
+    named :kw1, String
+    named :kw2, String, default: "kw2"
+    named :kw3, optional(String)
+
+    def call
+      "#{pos1}/#{pos2}/#{pos3}/#{kw1}/#{kw2}/#{kw3}"
     end
   end
 
@@ -106,6 +119,11 @@ class TypedOperationTest < ActiveSupport::TestCase
   def test_operation_optional_mix_args
     operation = TestKeywordAndPositionalOperation.new("first", kw1: "bar")
     assert_equal "first/pos2/bar/kw2", operation.call
+  end
+
+  def test_operation_alternative_dsl
+    operation = TestAlternativeDslOperation.new("first", kw1: "bar", kw3: "123")
+    assert_equal "first/pos2//bar/kw2/123", operation.call
   end
 
   def test_prepared

--- a/test/typed_operation_test.rb
+++ b/test/typed_operation_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 require "dry/monads"
 
@@ -11,10 +13,12 @@ class TypedOperationTest < ActiveSupport::TestCase
 
     param :foo, String
     param :bar, String
-    param :baz, String, convert: true
+    param :baz, String do |value|
+      value.to_s
+    end
 
     param :with_default, String, default: "qux"
-    param :can_be_nil, Integer, allow_nil: true
+    param :can_be_nil, Integer, allow_nil: true, default: nil
 
     def prepare
       @local_var = 123
@@ -99,5 +103,14 @@ class TypedOperationTest < ActiveSupport::TestCase
   def test_operation_invocation_with_missing_param
     partially_applied = TestOperation.with(foo: "1")
     assert_raises(TypedOperation::MissingParameterError) { partially_applied.call }
+  end
+
+  def test_missing_param_error_is_a_argument_error
+    partially_applied = TestOperation.with(foo: "1")
+    assert_raises(ArgumentError) { partially_applied.call }
+  end
+
+  def test_operation_creation_with_missing_param
+    assert_raises(ArgumentError) { TestOperation.new(foo: "1") }
   end
 end

--- a/test/typed_operation_test.rb
+++ b/test/typed_operation_test.rb
@@ -125,7 +125,7 @@ class TypedOperationTest < ActiveSupport::TestCase
     end
   end
 
-  def test_operation_raises_on_invalid_positional_params
+  def test_operation_raises_on_invalid_positional_params_using_optional
     assert_raises do
       Class.new(::TypedOperation::Base) do
         # This is invalid, because positional params can't be optional before required ones

--- a/test/typed_operation_test.rb
+++ b/test/typed_operation_test.rb
@@ -131,23 +131,25 @@ class TypedOperationTest < ActiveSupport::TestCase
   end
 
   def test_operation_instance_supports_pattern_matching_params
-    operation = TestOperation.new(foo: "1", bar: "2", baz: "3")
-    assert_equal ["1", "2", "3", "qux"], operation.deconstruct
-    assert_equal({foo: "1", bar: "2", baz: "3", with_default: "qux"}, operation.deconstruct_keys(%i[foo bar baz]))
+    operation = TestOperation.new(foo: "1", bar: "2", baz: "3", can_be_nil: 5)
+    assert_equal ["1", "2", "3", "qux", 5, nil], operation.deconstruct
+    assert_equal({foo: "1", bar: "2", baz: "3", with_default: "qux", can_be_nil: 5, can_also_be_nil: nil}, operation.deconstruct_keys(%i[foo bar baz]))
     case operation
     in TestOperation[foo: foo, with_default: default, **rest]
       assert_equal "1", foo
       assert_equal "qux", default
-      assert_equal({bar: "2", baz: "3"}, rest)
+      assert_equal({bar: "2", baz: "3", can_be_nil: 5, can_also_be_nil: nil}, rest)
     else
       raise "Pattern match failed"
     end
     case operation
-    in String => foo, String => bar, String => baz, String => with_default
+    in String => foo, String => bar, String => baz, String => with_default, Integer => can_be_nil, NilClass => can_also_be_nil
       assert_equal "1", foo
       assert_equal "2", bar
       assert_equal "3", baz
       assert_equal "qux", with_default
+      assert_equal 5, can_be_nil
+      assert_nil can_also_be_nil
     else
       raise "Pattern match failed"
     end

--- a/test/typed_operation_test.rb
+++ b/test/typed_operation_test.rb
@@ -10,7 +10,7 @@ class TypedOperationTest < ActiveSupport::TestCase
 
   class TestPositionalOperation < ::TypedOperation::Base
     param :first, String, positional: true
-    param :second, String, allow_nil: true, positional: true
+    param :second, String, optional: true, positional: true
 
     def call
       if second
@@ -42,7 +42,7 @@ class TypedOperationTest < ActiveSupport::TestCase
     end
 
     param :with_default, String, default: "qux"
-    param :can_be_nil, Integer, allow_nil: true
+    param :can_be_nil, Integer, optional: true
     param :can_also_be_nil, TypedOperation::Base, default: nil
 
     def prepare

--- a/test/typed_operation_test.rb
+++ b/test/typed_operation_test.rb
@@ -245,13 +245,14 @@ class TypedOperationTest < ActiveSupport::TestCase
     assert_equal ["1", "2", "3", "qux", 5, nil], operation.deconstruct
     assert_equal({foo: "1", bar: "2", baz: "3", with_default: "qux", can_be_nil: 5, can_also_be_nil: nil}, operation.deconstruct_keys(nil))
     assert_equal({foo: "1", can_be_nil: 5}, operation.deconstruct_keys(%i[foo can_be_nil]))
+
     case operation
     in TestOperation[foo: foo, with_default: default, **rest]
       assert_equal "1", foo
       assert_equal "qux", default
       assert_equal({bar: "2", baz: "3", can_be_nil: 5, can_also_be_nil: nil}, rest)
     else
-      raise Minitest::UnexpectedError, "Pattern match failed"
+      raise Minitest::Assertion, "Pattern match failed"
     end
     case operation
     in String => foo, String => bar, String => baz, String => with_default, Integer => can_be_nil, NilClass => can_also_be_nil
@@ -262,7 +263,7 @@ class TypedOperationTest < ActiveSupport::TestCase
       assert_equal 5, can_be_nil
       assert_nil can_also_be_nil
     else
-      raise Minitest::UnexpectedError, "Pattern match failed"
+      raise Minitest::Assertion, "Pattern match failed"
     end
   end
 
@@ -274,14 +275,14 @@ class TypedOperationTest < ActiveSupport::TestCase
       assert_equal "2", bar
       assert_equal({}, rest)
     else
-      raise Minitest::UnexpectedError, "Pattern match failed"
+      raise Minitest::Assertion, "Pattern match failed"
     end
     case partially_applied
     in String => foo, String => bar
       assert_equal "1", foo
       assert_equal "2", bar
     else
-      raise Minitest::UnexpectedError, "Pattern match failed"
+      raise Minitest::Assertion, "Pattern match failed"
     end
   end
 
@@ -294,7 +295,7 @@ class TypedOperationTest < ActiveSupport::TestCase
       assert_equal "2", bar
       assert_equal({baz: "3"}, rest)
     else
-      raise Minitest::UnexpectedError, "Pattern match failed"
+      raise Minitest::Assertion, "Pattern match failed"
     end
     case prepared
     in String => foo, String => bar, String => baz
@@ -302,7 +303,7 @@ class TypedOperationTest < ActiveSupport::TestCase
       assert_equal "2", bar
       assert_equal "3", baz
     else
-      raise Minitest::UnexpectedError, "Pattern match failed"
+      raise Minitest::Assertion, "Pattern match failed"
     end
   end
 end

--- a/test/typed_operation_test.rb
+++ b/test/typed_operation_test.rb
@@ -45,9 +45,20 @@ class TypedOperationTest < ActiveSupport::TestCase
     end
   end
 
-  class TestOperation < ::TypedOperation::Base
-    include Dry::Monads[:result]
+  class TestCurryOperation < ::TypedOperation::Base
+    positional :pos1, String
+    positional :pos2, String
+    positional :pos3, optional(String)
+    named :kw1, String
+    named :kw2, String
+    named :kw3, optional(String)
 
+    def call
+      "#{pos1}/#{pos2}/#{pos3}/#{kw1}/#{kw2}/#{kw3}"
+    end
+  end
+
+  class TestOperation < ::TypedOperation::Base
     param :foo, String
     param :bar, String
     param :baz, String do |value|
@@ -63,7 +74,7 @@ class TypedOperationTest < ActiveSupport::TestCase
     end
 
     def call
-      Success("It worked!")
+      "It worked, (#{foo}/#{bar}/#{baz}/#{with_default}/#{can_be_nil}/#{can_also_be_nil})"
     end
   end
 
@@ -154,7 +165,7 @@ class TypedOperationTest < ActiveSupport::TestCase
     assert_raises(ArgumentError) { TestPositionalOperation.new("first", "second", "third") }
   end
 
-  def test_positional_arg_count_must_make_sense_when_currying
+  def test_positional_arg_count_must_make_sense_when_partial_application
     assert_raises(ArgumentError) { TestPositionalOperation.with("first", "second", "third") }
   end
 
@@ -220,10 +231,8 @@ class TypedOperationTest < ActiveSupport::TestCase
     assert_equal 123, operation.instance_variable_get(:@local_var)
   end
 
-  def test_operation_success
-    result = TestOperation.call(foo: "1", bar: "2", baz: "3")
-    assert_instance_of Dry::Monads::Result::Success, result
-    assert_equal "It worked!", result.value!
+  def test_operation_invocation
+    assert_equal "It worked, (1/2/3/qux//)", TestOperation.call(foo: "1", bar: "2", baz: "3")
   end
 
   def test_raises_on_invalid_param_type
@@ -236,14 +245,13 @@ class TypedOperationTest < ActiveSupport::TestCase
   end
 
   def test_partially_applied_using_aliases
-    partially_applied = TestOperation[foo: "1"].curry(bar: "2")
+    partially_applied = TestOperation[foo: "1"]
     assert_instance_of TypedOperation::PartiallyApplied, partially_applied
   end
 
   def test_prepared_call
     result = TestOperation.with(foo: "1").with(bar: "2").with(baz: "3").call
-    assert_instance_of Dry::Monads::Result::Success, result
-    assert_equal "It worked!", result.value!
+    assert_equal "It worked, (1/2/3/qux//)", result
   end
 
   def test_prepared_operation_returns_an_instance_of_the_operation_with_attributes_set
@@ -353,5 +361,24 @@ class TypedOperationTest < ActiveSupport::TestCase
 
   def test_raises_when_operation_has_no_call_method_defined
     assert_raises(::TypedOperation::InvalidOperationError) { TestInvalidOperation.call }
+  end
+
+  def test_operation_of_one_required_param_can_curry
+    curried_operation = TestPositionalOperation.curry
+    assert_instance_of TypedOperation::Curried, curried_operation
+    assert_equal ["one!", "two!"], ["one", "two"].map(&curried_operation)
+  end
+
+  def test_operation_of_multliple_required_params_can_curry
+    curried_operation = TestOperation.curry
+    res = ["1", "2", 3].reduce(curried_operation) { |curried, arg| curried.call(arg) }
+    assert_equal "It worked, (1/2/3/qux//)", res
+  end
+
+  def test_operation_can_be_partially_applied_then_curry
+    partially_applied = TestCurryOperation.with("a", kw2: "e", kw3: "f")
+    curried_operation = partially_applied.curry
+    assert_instance_of TypedOperation::Curried, curried_operation
+    assert_equal "a/b//d/e/f", curried_operation.call("b").call("d")
   end
 end

--- a/typed_operation.gemspec
+++ b/typed_operation.gemspec
@@ -10,6 +10,8 @@ Gem::Specification.new do |spec|
   spec.description = "TypedOperation is a command pattern implementation where inputs can be defined with runtime type checks. Operations can be partially applied."
   spec.license = "MIT"
 
+  spec.required_ruby_version = ">= 3.1"
+
   spec.metadata["homepage_uri"] = spec.homepage
   spec.metadata["source_code_uri"] = "https://github.com/stevegeek/typed_operation"
 

--- a/typed_operation.gemspec
+++ b/typed_operation.gemspec
@@ -17,7 +17,5 @@ Gem::Specification.new do |spec|
     Dir["{app,config,db,lib}/**/*", "MIT-LICENSE", "Rakefile", "README.md"]
   end
 
-  spec.add_dependency "rails", ">= 6.0", "< 8.0"
-  spec.add_dependency "vident-typed", "~> 0.1.0"
-  spec.add_dependency "dry-initializer", "~> 3.0"
+  # spec.add_dependency "literal", "> 0.1.0", "< 1.0.0"
 end


### PR DESCRIPTION
TypedOperation::Base is now a subclass of Literal::Data.

Note these changes remove support for the 'convert:' param option, in favor of explicit coercion methods being provided by user